### PR TITLE
*Really* fix --long file decode, plus other bits

### DIFF
--- a/xbas99.py
+++ b/xbas99.py
@@ -412,8 +412,10 @@ class BasicProgram:
                       chrw(checksum) + chrw(lastAddr - 1))
             chunks = [(linoTable + tokenTable)[i:i + 254]
                       for i in xrange(0, len(linoTable + tokenTable), 254)]
-            return (chr(len(header)) + header +
-                    "".join([chr(len(c)) + c for c in chunks]))
+            return (chr(len(header)) + header + chr(0x00)*(len(header)-1) +
+		    chr(0xff) +
+		    (chr(0x00)*(254-len(header))) +  chr(0xfe) +
+                    "".join([chr(len(c)) + c + chr(0xff) for c in chunks]))
         else:
             header = (chrw(checksum) + chrw(tokenTabAddr - 1) +
                       chrw(linoTabAddr) + chrw(lastAddr - 1))
@@ -511,6 +513,8 @@ def main():
                     image = fin.read()
 	    if opts.astifiles:
 		    image = image[128:]
+	    if image[1:3] == "\xab\xcd":
+		long_ = True;
             if opts.merge:
                 program = BasicProgram()
                 program.merge(image)

--- a/xbas99.py
+++ b/xbas99.py
@@ -22,6 +22,7 @@
 import sys
 import re
 import os.path
+import traceback
 
 
 VERSION = "1.5.0"
@@ -169,15 +170,16 @@ class BasicProgram:
     # maximum number of bytes/tokens per BASIC line
     maxTokensPerLine = 254
     
-    def __init__(self, data=None, source=None, long_=False):
+    def __init__(self, data=None, source=None, long_=False, _tifiles=False):
         self.lines = {}
         self.textlits = []
         self.warnings = []
         if data:
             try:
-                self.load(data, long_)
+                self.load(data, long_, _tifiles)
             except IndexError:
                 self.warn("Program file is corrupted")
+		print traceback.format_exc()
         elif source:
             self.parse(source)
 
@@ -188,7 +190,13 @@ class BasicProgram:
 
     # program -> source
 
-    def load(self, data, long_):
+    def load(self, data, long_, _tifiles):
+	if _tifiles:
+		newdata = data[0:11]
+		print len(data)
+		for i in range(1, (len(data) / 255)):
+		   newdata += data[(i*256):(i*256)+255]
+		data = newdata
         """load tokenized BASIC program"""
         if long_ or data[1:3] == "\xab\xcd":
             # convert long format INT/VAR 254 to PROGRAM
@@ -470,6 +478,7 @@ class BasicProgram:
 
 def main():
     import argparse
+    tifiles = False
 
     args = argparse.ArgumentParser(
         version=VERSION,
@@ -513,13 +522,14 @@ def main():
                     image = fin.read()
 	    if opts.astifiles:
 		    image = image[128:]
+		    tifiles = True
 	    if image[1:3] == "\xab\xcd":
 		long_ = True;
             if opts.merge:
                 program = BasicProgram()
                 program.merge(image)
             else:
-                program = BasicProgram(data=image, long_=opts.long_)
+                program = BasicProgram(data=image, long_=opts.long_, _tifiles=tifiles)
             data = program.getSource()
             output = "-" if opts.list_ else opts.output or barename + ".b99"
         elif opts.dump:

--- a/xbas99.py
+++ b/xbas99.py
@@ -196,8 +196,7 @@ class BasicProgram:
             # convert long format INT/VAR 254 to PROGRAM
 	    if _tifiles:
 		newdata = data[0:11]
-		print len(data)
-		for i in range(1, (len(data) / 255)):
+		for i in range(1, (len(data) / 256)):
 		   newdata += data[(i*256):(i*256)+255]
 		data = newdata
             program, p = "", 11

--- a/xbas99.py
+++ b/xbas99.py
@@ -22,7 +22,6 @@
 import sys
 import re
 import os.path
-import traceback
 
 
 VERSION = "1.5.0"
@@ -170,16 +169,15 @@ class BasicProgram:
     # maximum number of bytes/tokens per BASIC line
     maxTokensPerLine = 254
     
-    def __init__(self, data=None, source=None, long_=False, _tifiles=False):
+    def __init__(self, data=None, source=None, long_=False):
         self.lines = {}
         self.textlits = []
         self.warnings = []
         if data:
             try:
-                self.load(data, long_, _tifiles)
+                self.load(data, long_)
             except IndexError:
                 self.warn("Program file is corrupted")
-		print traceback.format_exc()
         elif source:
             self.parse(source)
 
@@ -190,13 +188,7 @@ class BasicProgram:
 
     # program -> source
 
-    def load(self, data, long_, _tifiles):
-	if _tifiles:
-		newdata = data[0:11]
-		print len(data)
-		for i in range(1, (len(data) / 255)):
-		   newdata += data[(i*256):(i*256)+255]
-		data = newdata
+    def load(self, data, long_):
         """load tokenized BASIC program"""
         if long_ or data[1:3] == "\xab\xcd":
             # convert long format INT/VAR 254 to PROGRAM
@@ -476,7 +468,6 @@ class BasicProgram:
 
 def main():
     import argparse
-    tifiles = False
 
     args = argparse.ArgumentParser(
         version=VERSION,
@@ -520,12 +511,11 @@ def main():
                     image = fin.read()
 	    if opts.astifiles:
 		    image = image[128:]
-		    tifiles = True
             if opts.merge:
                 program = BasicProgram()
                 program.merge(image)
             else:
-                program = BasicProgram(data=image, long_=opts.long_, _tifiles=tifiles)
+                program = BasicProgram(data=image, long_=opts.long_)
             data = program.getSource()
             output = "-" if opts.list_ else opts.output or barename + ".b99"
         elif opts.dump:

--- a/xbas99.py
+++ b/xbas99.py
@@ -22,6 +22,7 @@
 import sys
 import re
 import os.path
+import traceback
 
 
 VERSION = "1.5.0"
@@ -169,15 +170,16 @@ class BasicProgram:
     # maximum number of bytes/tokens per BASIC line
     maxTokensPerLine = 254
     
-    def __init__(self, data=None, source=None, long_=False):
+    def __init__(self, data=None, source=None, long_=False, _tifiles=False):
         self.lines = {}
         self.textlits = []
         self.warnings = []
         if data:
             try:
-                self.load(data, long_)
+                self.load(data, long_, _tifiles)
             except IndexError:
                 self.warn("Program file is corrupted")
+		print traceback.format_exc()
         elif source:
             self.parse(source)
 
@@ -188,7 +190,13 @@ class BasicProgram:
 
     # program -> source
 
-    def load(self, data, long_):
+    def load(self, data, long_, _tifiles):
+	if _tifiles:
+		newdata = data[0:11]
+		print len(data)
+		for i in range(1, (len(data) / 255)):
+		   newdata += data[(i*256):(i*256)+255]
+		data = newdata
         """load tokenized BASIC program"""
         if long_ or data[1:3] == "\xab\xcd":
             # convert long format INT/VAR 254 to PROGRAM
@@ -468,6 +476,7 @@ class BasicProgram:
 
 def main():
     import argparse
+    tifiles = False
 
     args = argparse.ArgumentParser(
         version=VERSION,
@@ -511,11 +520,12 @@ def main():
                     image = fin.read()
 	    if opts.astifiles:
 		    image = image[128:]
+		    tifiles = True
             if opts.merge:
                 program = BasicProgram()
                 program.merge(image)
             else:
-                program = BasicProgram(data=image, long_=opts.long_)
+                program = BasicProgram(data=image, long_=opts.long_, _tifiles=tifiles)
             data = program.getSource()
             output = "-" if opts.list_ else opts.output or barename + ".b99"
         elif opts.dump:

--- a/xbas99.py
+++ b/xbas99.py
@@ -516,6 +516,8 @@ def main():
             else:
                 with open(opts.source, "rb") as fin:
                     image = fin.read()
+	    if image[1:8] == "TIFILES":
+		    opts.astifiles = True
 	    if opts.astifiles:
 		    image = image[128:]
 		    tifiles = True

--- a/xbas99.py
+++ b/xbas99.py
@@ -170,13 +170,13 @@ class BasicProgram:
     # maximum number of bytes/tokens per BASIC line
     maxTokensPerLine = 254
     
-    def __init__(self, data=None, source=None, long_=False, _tifiles=False):
+    def __init__(self, data=None, source=None, long_=False, tifiles_=False):
         self.lines = {}
         self.textlits = []
         self.warnings = []
         if data:
             try:
-                self.load(data, long_, _tifiles)
+                self.load(data, long_, tifiles_)
             except IndexError:
                 self.warn("Program file is corrupted")
 		print traceback.format_exc()
@@ -190,8 +190,8 @@ class BasicProgram:
 
     # program -> source
 
-    def load(self, data, long_, _tifiles):
-	if _tifiles:
+    def load(self, data, long_, tifiles_):
+	if long_ and tifiles_:
 		newdata = data[0:11]
 		for i in range(1, (len(data) / 256)):
 		   newdata += data[(i*256):(i*256)+255]
@@ -523,12 +523,12 @@ def main():
 		    image = image[128:]
 		    tifiles = True
 	    if image[1:3] == "\xab\xcd":
-		long_ = True
+		opts.long_ = True
             if opts.merge:
                 program = BasicProgram()
                 program.merge(image)
             else:
-                program = BasicProgram(data=image, long_=opts.long_, _tifiles=tifiles)
+                program = BasicProgram(data=image, long_=opts.long_, tifiles_=tifiles)
             data = program.getSource()
             output = "-" if opts.list_ else opts.output or barename + ".b99"
         elif opts.dump:

--- a/xbas99.py
+++ b/xbas99.py
@@ -419,9 +419,7 @@ class BasicProgram:
                       chrw(checksum) + chrw(lastAddr - 1))
             chunks = [(linoTable + tokenTable)[i:i + 254]
                       for i in xrange(0, len(linoTable + tokenTable), 254)]
-            return (chr(len(header)) + header + chr(0x00)*(len(header)-1) +
-		    chr(0xff) +
-		    (chr(0x00)*(254-len(header))) +  chr(0xfe) +
+            return (chr(len(header)) + header + (chr(0x00)*(256-len(header)) +
                     "".join([chr(len(c)) + c + chr(0xff) for c in chunks]))
         else:
             header = (chrw(checksum) + chrw(tokenTabAddr - 1) +

--- a/xbas99.py
+++ b/xbas99.py
@@ -196,7 +196,8 @@ class BasicProgram:
             # convert long format INT/VAR 254 to PROGRAM
 	    if _tifiles:
 		newdata = data[0:11]
-		for i in range(1, (len(data) / 256)):
+		print len(data)
+		for i in range(1, (len(data) / 255)):
 		   newdata += data[(i*256):(i*256)+255]
 		data = newdata
             program, p = "", 11

--- a/xbas99.py
+++ b/xbas99.py
@@ -191,15 +191,15 @@ class BasicProgram:
     # program -> source
 
     def load(self, data, long_, _tifiles):
-	if _tifiles:
+        """load tokenized BASIC program"""
+        if long_ or data[1:3] == "\xab\xcd":
+            # convert long format INT/VAR 254 to PROGRAM
+	    if _tifiles:
 		newdata = data[0:11]
 		print len(data)
 		for i in range(1, (len(data) / 255)):
 		   newdata += data[(i*256):(i*256)+255]
 		data = newdata
-        """load tokenized BASIC program"""
-        if long_ or data[1:3] == "\xab\xcd":
-            # convert long format INT/VAR 254 to PROGRAM
             program, p = "", 11
             while p < len(data):
                 l = ord(data[p]) + 1

--- a/xbas99.py
+++ b/xbas99.py
@@ -191,15 +191,15 @@ class BasicProgram:
     # program -> source
 
     def load(self, data, long_, _tifiles):
-        """load tokenized BASIC program"""
-        if long_ or data[1:3] == "\xab\xcd":
-            # convert long format INT/VAR 254 to PROGRAM
-	    if _tifiles:
+	if _tifiles:
 		newdata = data[0:11]
 		print len(data)
 		for i in range(1, (len(data) / 255)):
 		   newdata += data[(i*256):(i*256)+255]
 		data = newdata
+        """load tokenized BASIC program"""
+        if long_ or data[1:3] == "\xab\xcd":
+            # convert long format INT/VAR 254 to PROGRAM
             program, p = "", 11
             while p < len(data):
                 l = ord(data[p]) + 1

--- a/xbas99.py
+++ b/xbas99.py
@@ -191,19 +191,18 @@ class BasicProgram:
     # program -> source
 
     def load(self, data, long_, tifiles_):
-	if long_ and tifiles_:
-		newdata = data[0:11]
-		for i in range(1, (len(data) / 256)):
-		   newdata += data[(i*256):(i*256)+255]
-		data = newdata
         """load tokenized BASIC program"""
         if long_ or data[1:3] == "\xab\xcd":
             # convert long format INT/VAR 254 to PROGRAM
-            program, p = "", 11
+	    if tifiles_:
+	        p = 128
+	    else:
+		p = 11
+            program = ""
             while p < len(data):
                 l = ord(data[p]) + 1
                 program += data[p + 1:p + l]
-                p += l
+                p += l + 1
             data = "XX" + data[5:7] + data[3:5] + "XX" + program
         # extract line number table and token table
         ptrTokens = ordw(data[2:4]) + 1

--- a/xbas99.py
+++ b/xbas99.py
@@ -419,7 +419,7 @@ class BasicProgram:
                       chrw(checksum) + chrw(lastAddr - 1))
             chunks = [(linoTable + tokenTable)[i:i + 254]
                       for i in xrange(0, len(linoTable + tokenTable), 254)]
-            return (chr(len(header)) + header + (chr(0x00)*(256-len(header)) +
+            return (chr(len(header)) + header + (chr(0x00)*(256-len(header))) +
                     "".join([chr(len(c)) + c + chr(0xff) for c in chunks]))
         else:
             header = (chrw(checksum) + chrw(tokenTabAddr - 1) +

--- a/xbas99.py
+++ b/xbas99.py
@@ -523,7 +523,7 @@ def main():
 		    image = image[128:]
 		    tifiles = True
 	    if image[1:3] == "\xab\xcd":
-		long_ = True;
+		long_ = True
             if opts.merge:
                 program = BasicProgram()
                 program.merge(image)

--- a/xbas99.py
+++ b/xbas99.py
@@ -493,6 +493,8 @@ def main():
                       help="join split source lines (for -e)")
     args.add_argument("-o", "--output", dest="output", metavar="<file>",
                       help="set output filename")
+    args.add_argument("-t", "--tifiles", action="store_true", dest="astifiles",
+                      help="assume TIFILES format program to list or decode")
     opts = args.parse_args()
 
     #setup
@@ -507,6 +509,8 @@ def main():
             else:
                 with open(opts.source, "rb") as fin:
                     image = fin.read()
+	    if opts.astifiles:
+		    image = image[128:]
             if opts.merge:
                 program = BasicProgram()
                 program.merge(image)

--- a/xbas99.py
+++ b/xbas99.py
@@ -193,8 +193,7 @@ class BasicProgram:
     def load(self, data, long_, _tifiles):
 	if _tifiles:
 		newdata = data[0:11]
-		print len(data)
-		for i in range(1, (len(data) / 255)):
+		for i in range(1, (len(data) / 256)):
 		   newdata += data[(i*256):(i*256)+255]
 		data = newdata
         """load tokenized BASIC program"""

--- a/xdm99.py
+++ b/xdm99.py
@@ -167,7 +167,11 @@ class Disk:
             if error:
                 fd.error = True
             self.catalog[fd.name] = File(fd=fd, data=data)
-            scount += fd.totalSectors + 1
+	    # Myarc DSDD80T always uses multiple of 512 bytes, including dir
+	    # entries
+	    if ((fd.totalSectors % 2) != 0) and Disk.clusterSize == 2:
+	        fd.totalSectors += 1
+            scount += fd.totalSectors + Disk.clusterSize
         # consistency check
         if scount != self.usedSectors - 2:
             self.warn(
@@ -196,7 +200,7 @@ class Disk:
 	    expectedLength = Disk.bytesPerSector * (sectors+1)
 	else:
 	    expectedLength = Disk.bytesPerSector * sectors
-	
+
         if len(data) != expectedLength:
             self.warn("%s: File size mismatch: found %d bytes, expected %d" % (
                 name, len(data), sectors * Disk.bytesPerSector))

--- a/xdm99.py
+++ b/xdm99.py
@@ -99,8 +99,9 @@ class Disk:
     bytesPerSector = 256
     defaultSectorsPerTrack = 9
     defaultTracks = 40
-    maxSectors = 1600
+    maxSectors = 2880
     blankByte = "\xe5"
+    clusterSize = 1
     
     def __init__(self, image):
         if len(image) < 2 * Disk.bytesPerSector:
@@ -125,10 +126,13 @@ class Disk:
         if len(self.image) < self.totalSectors * Disk.bytesPerSector:
             self.warn("Disk image truncated", "image")
         self.checkGeometry()
+	if self.totalSectors == 2880:
+	    Disk.clusterSize = 2
         self.usedSectors = 0
         try:
-            for i in xrange(used(self.totalSectors, 8)):
-                self.usedSectors += bin(ord(self.allocBitmap[i])).count("1")
+            for i in xrange(used(self.totalSectors / self.clusterSize, 8)):
+                    self.usedSectors += bin(ord(self.allocBitmap[i])).count("1") * self.clusterSize
+
         except IndexError:
             self.warn("Allocation map corrupted", "alloc")
         self.catalog = {}
@@ -187,7 +191,13 @@ class Disk:
                     self.warn("%s: File contents corrupted" % name)
                     error = True
                     continue
-        if len(data) != sectors * Disk.bytesPerSector:
+	if Disk.clusterSize is 2 and ((Disk.bytesPerSector * sectors) % 512):
+	    # pad to multiple of 2 sectors for DSDD80T
+	    expectedLength = Disk.bytesPerSector * (sectors+1)
+	else:
+	    expectedLength = Disk.bytesPerSector * sectors
+	
+        if len(data) != expectedLength:
             self.warn("%s: File size mismatch: found %d bytes, expected %d" % (
                 name, len(data), sectors * Disk.bytesPerSector))
             error = True
@@ -321,10 +331,11 @@ class Disk:
         """check sector allocation for consistency"""
         reads = {n: [] for n in xrange(self.totalSectors)}
         allocated = []
-        for i in xrange(used(self.totalSectors, 8)):
+	for i in xrange(used(self.totalSectors / self.clusterSize, 8)):
             byte = ord(self.allocBitmap[i])
-            for j in xrange(8):
-                allocated.append(byte & 1 << j != 0)
+	    for j in xrange(8):
+		for k in xrange(self.clusterSize):
+                    allocated.append(byte & 1 << j != 0)
         # unallocated sectors
         for n, context in self.readSectors:
             reads[n].append(context)


### PR DESCRIPTION
It turns out there was an off-by-one in the record seek logic that fouled up --long decodes.

I've also turned on stack backtrace for the parser, so that we can debug this:

```
Traceback (most recent call last):
  File "/home/wileyc/bin/xbas99.py", line 574, in <module>
    status = main()
  File "/home/wileyc/bin/xbas99.py", line 531, in main
    data = program.getSource()
  File "/home/wileyc/bin/xbas99.py", line 266, in getSource
    istext = (lit[0] in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
TypeError: 'NoneType' object has no attribute '__getitem__'
```

... there's an invalid opcode (0xff) creeping in somewhere, and I think it's an end-of-record marker that isn't getting purged by the long-to-short routine.

Finally, I turned on autodetect for long and TIFILES format files based on first few characters of the file.
