### PR TITLE
Fixed two tutorial bugs.

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -281,7 +281,7 @@ option 5 using the image option `-i`.
     $ xas99.py -R -i ashello.asm -o ashello5.img
 
 Again, we override the default output name `ashello.img`, for later.  The
-resulting image file `ashello5.img` has 248 bytes and contains binary data.
+resulting image file `ashello5.img` has 132 bytes and contains binary data.
 
     $ ls -l ashello5.img
     > dir ashello5.img

--- a/examples/ashello.asm
+++ b/examples/ashello.asm
@@ -2,6 +2,7 @@
 
        IDT 'ASHELLO'
 
+       DEF START
        REF VSBW,VMBW,VWTR
        REF KSCAN
 


### PR DESCRIPTION
Official tutorial says in a paragraph:

"The resulting image file ashello5.img has 248 bytes", but then an "ls -l" is offered to confirm and it correctly shows that the size is 132. It's gonna be 248 when the file is assembled with all .asm providing referenced symbols.

The other fix is a bug in ashello.asm. It was missing a fundamental "DEF START" at the preamble. The omission was causing the symbol not to be included in the .obj. Consequently, when entering START as program name in E/A #3 (Load and Run), it was causing a "PROGRAM NOT FOUND" error.