### PR TITLE
Fixed errors in ashello_new.asm

### DIFF
--- a/examples/ashello_new.asm
+++ b/examples/ashello_new.asm
@@ -3,7 +3,6 @@
        idt 'ashello'
 
        def sload, sfirst, slast, start
-       ref kscan
 
        jmp  start
 
@@ -49,7 +48,7 @@ next:
        movb r9, @gpl_status
 
 !      movb r9, @keymode
-       bl   @kscan
+       blwp @kscan
        cb   @keycode, r8
        jeq  -!
 
@@ -64,5 +63,6 @@ next:
        copy "vsbw.asm"
        copy "vmbw.asm"
        copy "vwtr.asm"
+       copy "kscan_ea.asm"
 
        end


### PR DESCRIPTION
The new syntax source file had a non-honored reference to kscan (non-honored: the corresponding copy was missing).
I fixed it by copying "keyscan_ea.asm", although for that one to work, I needed to replace the "bl kscan" (branch-and-link) command with "blwp kscan" (branch-and-load-workspace-pointer).

Not copying the file had a consequence: the program image (option -i) couldn't be created unless kscan_ea.asm was added to the command line every time. But being other copies already there, why not adding this one so this example is a stand-alone case?
Not changing "bl" in favor of "blwp" had another consequence: kscan was actually messing things up and the screen border wasn't really changing in response to pressed keys.